### PR TITLE
Fix bug and some improvements to the library

### DIFF
--- a/library.json
+++ b/library.json
@@ -9,5 +9,5 @@
   },
   "frameworks": "arduino",
   "platforms": "espressif8266",
-  "version": "1.0.5"
+  "version": "1.0.6"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=IOTAppStory-ESP8266
-version=1.0.5
+version=1.0.6
 author=SensorsIot
 maintainer=iotappstory
 sentence=Livecycle Infrastructure for IOT Devices

--- a/src/IOTAppStory.cpp
+++ b/src/IOTAppStory.cpp
@@ -21,15 +21,12 @@ extern "C" {
 
 IOTAppStory::IOTAppStory(const char *appName, const char *appVersion, const char *compDate, const int modeButton){
 	// initiating object
-	//_appName = appName;			// may not be necessary
+	_appName = appName;
 	//_appVersion = appVersion;		// may not be necessary
 	_firmware = String(appName)+" "+String(appVersion);
 	_compDate = compDate;
 	_modeButton = modeButton;
-	readConfig();
-	
-	// set appName as default boardName in case the app developer does not set it
-	preSetConfig((String)appName, false);
+
 }
 
 void IOTAppStory::firstBoot(bool ea){
@@ -75,6 +72,9 @@ void IOTAppStory::serialdebug(bool onoff,int speed){
 
 
 void IOTAppStory::preSetConfig(bool automaticUpdate){
+	if (!_configReaded) {
+		readConfig();
+	}
 	SetConfigValue(config.automaticUpdate, automaticUpdate, _setPreSet);
 }
 
@@ -100,9 +100,21 @@ void IOTAppStory::preSetConfig(String ssid, String password, String boardName, S
 	SetConfigValueCharArray(config.IOTappStoryPHP1, IOTappStoryPHP1, STRUCT_CHAR_ARRAY_SIZE, _setPreSet);
 }
 
+
 void IOTAppStory::begin(bool bootstats, bool ea){
 	DEBUG_PRINTLN("\n");
-
+	
+	// read config if needed
+	if (!_configReaded) {
+		readConfig();
+	}
+	
+	// set appName as default boardName in case the app developer does not set it
+	if (config.boardName == "yourFirstApp") {
+		preSetConfig(_appName, config.automaticUpdate);
+	}
+	
+	// write config if detected changes
 	if(_setPreSet == true){
 		writeConfig();
 		DEBUG_PRINTLN("Saving config presets...\n");
@@ -744,6 +756,9 @@ bool IOTAppStory::readConfig() {
 		writeConfig();
 		ret = false;
 	}
+	
+	_configReaded = true;
+	
 	return ret;
 }
 

--- a/src/IOTAppStory.cpp
+++ b/src/IOTAppStory.cpp
@@ -332,7 +332,7 @@ byte IOTAppStory::iotUpdater(bool type, String server, String url) {
 	t_httpUpdate_return ret;
 	if(type == 0){
 		// type == sketch
-		ret = ESPhttpUpdate.update(server, 80, url, _firmware);
+		ret = ESPhttpUpdate.update("http://" + String(server + url), _firmware);
 	}
 	if(type == 1){
 		// type == spiffs

--- a/src/IOTAppStory.cpp
+++ b/src/IOTAppStory.cpp
@@ -73,35 +73,31 @@ void IOTAppStory::serialdebug(bool onoff,int speed){
 	}
 }
 
+
 void IOTAppStory::preSetConfig(bool automaticUpdate){
-	config.automaticUpdate = automaticUpdate;
-	_setPreSet = true;
+	SetConfigValue(config.automaticUpdate, automaticUpdate, _setPreSet);
 }
 
 void IOTAppStory::preSetConfig(String boardName, bool automaticUpdate /*= false*/){
-	boardName.toCharArray(config.boardName, STRUCT_CHAR_ARRAY_SIZE);
-	config.automaticUpdate = automaticUpdate;
-	_setPreSet = true;
+	preSetConfig(automaticUpdate);
+	SetConfigValueCharArray(config.boardName, boardName, STRUCT_CHAR_ARRAY_SIZE, _setPreSet);
 }
 
 void IOTAppStory::preSetConfig(String ssid, String password, bool automaticUpdate /*= false*/){
-	ssid.toCharArray(config.ssid, STRUCT_CHAR_ARRAY_SIZE);
-	password.toCharArray(config.password, STRUCT_CHAR_ARRAY_SIZE);
-	config.automaticUpdate = automaticUpdate;
-	_setPreSet = true;
+	preSetConfig(automaticUpdate);
+	SetConfigValueCharArray(config.ssid, ssid, STRUCT_CHAR_ARRAY_SIZE, _setPreSet);
+	SetConfigValueCharArray(config.password, password, STRUCT_CHAR_ARRAY_SIZE, _setPreSet);
 }
 
 void IOTAppStory::preSetConfig(String ssid, String password, String boardName, bool automaticUpdate /*= false*/){
 	preSetConfig(ssid, password, automaticUpdate);
-	boardName.toCharArray(config.boardName, STRUCT_CHAR_ARRAY_SIZE);
-	_setPreSet = true;
+	SetConfigValueCharArray(config.boardName, boardName, STRUCT_CHAR_ARRAY_SIZE, _setPreSet);
 }
 
 void IOTAppStory::preSetConfig(String ssid, String password, String boardName, String IOTappStory1, String IOTappStoryPHP1, bool automaticUpdate /*= false*/) {
 	preSetConfig(ssid, password, boardName, automaticUpdate);
-	IOTappStory1.toCharArray(config.IOTappStory1, STRUCT_HOST_SIZE);
-	IOTappStoryPHP1.toCharArray(config.IOTappStoryPHP1, STRUCT_FILE_SIZE);
-	_setPreSet = true;
+	SetConfigValueCharArray(config.IOTappStory1, IOTappStory1, STRUCT_CHAR_ARRAY_SIZE, _setPreSet);
+	SetConfigValueCharArray(config.IOTappStoryPHP1, IOTappStoryPHP1, STRUCT_CHAR_ARRAY_SIZE, _setPreSet);
 }
 
 void IOTAppStory::begin(bool bootstats, bool ea){

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -30,6 +30,13 @@
     #else
         #define DEBUG_MSG(...)
     #endif
+	
+	
+	// set to true to include code for show EEPROM contents in debug
+	#ifndef DEBUG_EEPROM_CONFIG
+		#define DEBUG_EEPROM_CONFIG false
+	#endif
+
 
     //#ifdef SERIALDEBUG
     #define         DEBUG_PRINT(x)    { if(_serialDebug) Serial.print(x);   }
@@ -160,6 +167,17 @@
             int     _nrXF = 0;				// nr of extra fields required in the config manager
             bool    _serialDebug;
             bool    _setPreSet = false;		// ;)
+			/* ------ CONVERT BYTE TO STRING 								 */
+			String GetCharToDisplayInDebug(char value) {
+				if (value>=32 && value<=126){
+					return String(value);
+				} else if (value == 0){
+					return ".";
+				} else {
+					return String("[" + String(value, DEC) + "]");
+				} 
+			}
+			
     };
 
 #endif

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -9,7 +9,6 @@
     #define MAXNUMEXTRAFIELDS 12
     #define MAGICEEP "%"
     #define UDP_PORT 514
-    #define MAX_WIFI_RETRIES 15
     #define RTCMEMBEGIN 68
     #define MAGICBYTE 85
     #define STRUCT_CHAR_ARRAY_SIZE 50  // length of config variables
@@ -23,6 +22,10 @@
     #define ENTER_CONFIG_MODE_TIME_MIN    ENTER_CHECK_FIRMWARE_TIME_MAX
     #define ENTER_CONFIG_MODE_TIME_MAX    10000
 
+	// sets the default value for the maximum number of retries when trying to connect to the wifi
+	#ifndef MAX_WIFI_RETRIES
+		#define MAX_WIFI_RETRIES 15
+	#endif // !MAX_WIFI_RETRIES
 
     // macros for debugging
     #ifdef DEBUG_PORT

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -159,7 +159,7 @@
             void sendDebugMessage();
 
         private:
-            //String  _appName;				// may not be necessary
+            String  _appName;
             //String  _appVersion;			// may not be necessary
             String  _firmware;
             String  _compDate;
@@ -167,6 +167,7 @@
             int     _nrXF = 0;				// nr of extra fields required in the config manager
             bool    _serialDebug;
             bool    _setPreSet = false;		// ;)
+			bool	_configReaded = false;
 			const static bool _boolDefaulValue = false;
 
 			

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -167,6 +167,33 @@
             int     _nrXF = 0;				// nr of extra fields required in the config manager
             bool    _serialDebug;
             bool    _setPreSet = false;		// ;)
+			const static bool _boolDefaulValue = false;
+
+			
+			
+			/* ------ ------ ------ AUXILIARY FUNCTIONS ------ ------ ------ */
+			/* ------ CHANGE CONFIG VALUES 									 */
+			template <typename T, typename T2> bool SetConfigValue(T &a, T2 &b, bool &changeFlag = _boolDefaulValue) {
+				if (a != b) {
+					a = b;
+					changeFlag = true;
+					return true;
+				} else {
+					return false;
+				}
+			}
+
+			bool SetConfigValueCharArray(char* a, String &b, int len, bool changeFlag = &_boolDefaulValue) {
+				if (b != a) {
+					b.toCharArray(a, len);
+					changeFlag = true;
+					return true;
+				} else {
+					return false;
+				}
+			}
+			/* ------ */
+			
 			/* ------ CONVERT BYTE TO STRING 								 */
 			String GetCharToDisplayInDebug(char value) {
 				if (value>=32 && value<=126){


### PR DESCRIPTION
## Allow another port when download firmware
Allow use another port when download firmware, current version have port 80 hardcoded.

## Debug EEPROM (read/Write)
Show in debug what is read/write in EEPROM.
Can enable debug puting this code "**`#define DEBUG_EEPROM_CONFIG true`**" in the user schetch.

## Write to EEPROM only if config change
**_BUG:_** the current version always writes to the EEPROM when boots, because the field "**`_setPreSet`**" is always **`true`** when boot.
With this code only writes to EEPROM when config is changed.

## Only initialize fields in constructor
Do not execute complex code in constructor (ex: readConfig), the execution of this code can't be debuged there, because the debug flag is not yet set.
The execution of this code must be delayed until call **`begin `** method.

#
Thanks for this great library :)
Best regards,

Ricardo Carvalho
ricardocarvalho@c-core.org