### PR TITLE
Added compilation options and ability to control EEPROM clearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,20 @@ loop () {
 }
 ```
 
-### `begin(bool bootstat, bool ea)`
+### `begin(bool bootstat, bool ea, bool ee)`
 
 Set up IAS and start all dependent services. 
 
 If `bootstat` is true, the code will keep track of number of boots and print
 contents of RTC memory.
 
-If `ea` is true, the EEPROM (wifi credentials and IAS activation code) will be
+If `ea` is true, the entire EEPROM (including wifi credentials and IAS activation code) will be
+erased.
+
+If `ee` is true and `ea` is false, some of the EEPROM ( excluding wifi credentials and IAS activation code) will be
+erased.
+
+If `ee` is flase and `ea` is false (or excluded), none of the EEPROM (including wifi credentials and IAS activation code) will be
 erased.
 
 ### `buttonLoop()`

--- a/README.md
+++ b/README.md
@@ -9,15 +9,14 @@ Wiki pages: https://iotappstory.com/wiki
 ### `IOTAppStory(char* appName, char* appVersion, char* compDate, char* modeButton)`
 
 Tells IAS the name of the application, its version, compilation date and what
-digital input is the force-update/reset button. Note: the EEPROM size and number of firmware variables are limited to 1024 and 12 respectively. If additional resources are needed beyond these limits `LOCAL_EEPROM_SIZE` and `LOCAL_MAXNUMEXTRAFIELDS` can be defined.
+digital input is the force-update/reset button. Note: the EEPROM size and number of firmware variables are limited to 1024 and 12 respectively. If additional resources are needed beyond these limits `EEPROM_SIZE` and `MAXNUMEXTRAFIELDS` can be defined / modified in `IOTAppStory.h`.
 
 ```c
 #define APPNAME my_app
 #define VERSION V1.0.0
 #define COMPDATE __DATE__ __TIME__
 #define MODE_BUTTON D3
-//#define LOCAL_EEPROM_SIZE 2048
-//#define LOCAL_MAXNUMEXTRAFIELDS 20
+
 
 #include <IOTAppStory.h>
 IOTAppStory IAS(APPNAME, VERSION, COMPDATE, MODEBUTTON);

--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ Wiki pages: https://iotappstory.com/wiki
 ### `IOTAppStory(char* appName, char* appVersion, char* compDate, char* modeButton)`
 
 Tells IAS the name of the application, its version, compilation date and what
-digital input is the force-update/reset button.
+digital input is the force-update/reset button. Note: the EEPROM size and number of firmware variables are limited to 1024 and 12 respectively. If additional resources are needed beyond these limits `LOCAL_EEPROM_SIZE` and `LOCAL_MAXNUMEXTRAFIELDS` can be defined.
 
 ```c
 #define APPNAME my_app
 #define VERSION V1.0.0
 #define COMPDATE __DATE__ __TIME__
 #define MODE_BUTTON D3
+//#define LOCAL_EEPROM_SIZE 2048
+//#define LOCAL_MAXNUMEXTRAFIELDS 20
 
 #include <IOTAppStory.h>
 IOTAppStory IAS(APPNAME, VERSION, COMPDATE, MODEBUTTON);

--- a/examples/IASLoader/IASLoader.ino
+++ b/examples/IASLoader/IASLoader.ino
@@ -28,6 +28,8 @@
 #define VERSION "V1.0.0"
 #define COMPDATE __DATE__ __TIME__
 #define MODEBUTTON 0
+//#define LOCAL_EEPROM_SIZE 2048	// optional definition parameter to allow for increased EEPROM size; up to 4096 for ESP8266
+//#define LOCAL_MAXNUMEXTRAFIELDS	// optional definition parameter to allow for increased firmware variables
 
 
 #include <ESP8266WiFi.h>

--- a/examples/IASLoader/IASLoader.ino
+++ b/examples/IASLoader/IASLoader.ino
@@ -28,8 +28,6 @@
 #define VERSION "V1.0.0"
 #define COMPDATE __DATE__ __TIME__
 #define MODEBUTTON 0
-//#define LOCAL_EEPROM_SIZE 2048	// optional definition parameter to allow for increased EEPROM size; up to 4096 for ESP8266
-//#define LOCAL_MAXNUMEXTRAFIELDS 20	// optional definition parameter to allow for increased firmware variables
 
 
 #include <ESP8266WiFi.h>

--- a/examples/IASLoader/IASLoader.ino
+++ b/examples/IASLoader/IASLoader.ino
@@ -29,7 +29,7 @@
 #define COMPDATE __DATE__ __TIME__
 #define MODEBUTTON 0
 //#define LOCAL_EEPROM_SIZE 2048	// optional definition parameter to allow for increased EEPROM size; up to 4096 for ESP8266
-//#define LOCAL_MAXNUMEXTRAFIELDS	// optional definition parameter to allow for increased firmware variables
+//#define LOCAL_MAXNUMEXTRAFIELDS 20	// optional definition parameter to allow for increased firmware variables
 
 
 #include <ESP8266WiFi.h>

--- a/examples/IASLoader/IASLoader.ino
+++ b/examples/IASLoader/IASLoader.ino
@@ -45,7 +45,8 @@ void setup() {
   boardName = APPNAME"_" + WiFi.macAddress();
   IAS.preSetConfig(boardName, false);	    // preset Boardname, automatic upload false
 
-  IAS.begin(true, true);									// 1st parameter: true or false to view BOOT STATISTICS | 2nd parameter: true or false to erase eeprom on first boot of the app
+  IAS.begin(true, true);									// 1st parameter: true or false to view BOOT STATISTICS | 2nd parameter: true or false to erase eeprom and config settings on first boot of the app  
+  //IAS.begin(true, false, true);								// 1st parameter: true or false to view BOOT STATISTICS | 2nd parameter: true or false to erase config settings on first boot of the app | 3rd parameter: true or false to erase eeprom on first boot of the app	  
   IAS.callHome(true);
 
   //-------- Your Setup starts from here ---------------

--- a/examples/VirginSoil_Full/VirginSoil_Full.ino
+++ b/examples/VirginSoil_Full/VirginSoil_Full.ino
@@ -77,9 +77,11 @@ void setup() {
   /* TIP! delete the lines above when not used */
 
 
-  IAS.begin(true);																										// 1st parameter: true or false to view BOOT STATISTICS | 2nd parameter: true or false to erase eeprom on first boot of the app
+  IAS.begin(true);						    // 1st parameter: true or false to view BOOT STATISTICS | 2nd parameter: true or false to erase eeprom on first boot of the app
+  //IAS.begin(true, false, true);				    // 1st parameter: true or false to view BOOT STATISTICS | 2nd parameter: true or false to erase config settings on first boot of the app | 3rd parameter: true or false to erase eeprom on first boot of the app	  
 
 
+	
   //-------- Your Setup starts from here ---------------
 
 }

--- a/examples/VirginSoil_Full/VirginSoil_Full.ino
+++ b/examples/VirginSoil_Full/VirginSoil_Full.ino
@@ -29,8 +29,6 @@
 #define VERSION "V2.1.1"
 #define COMPDATE __DATE__ __TIME__
 #define MODEBUTTON 0
-//#define LOCAL_EEPROM_SIZE 2048	// optional definition parameter to allow for increased EEPROM size; up to 4096 for ESP8266
-//#define LOCAL_MAXNUMEXTRAFIELDS 20	// optional definition parameter to allow for increased firmware variables
 
 
 #include <IOTAppStory.h>

--- a/examples/VirginSoil_Full/VirginSoil_Full.ino
+++ b/examples/VirginSoil_Full/VirginSoil_Full.ino
@@ -30,7 +30,7 @@
 #define COMPDATE __DATE__ __TIME__
 #define MODEBUTTON 0
 //#define LOCAL_EEPROM_SIZE 2048	// optional definition parameter to allow for increased EEPROM size; up to 4096 for ESP8266
-//#define LOCAL_MAXNUMEXTRAFIELDS	// optional definition parameter to allow for increased firmware variables
+//#define LOCAL_MAXNUMEXTRAFIELDS 20	// optional definition parameter to allow for increased firmware variables
 
 
 #include <IOTAppStory.h>

--- a/examples/VirginSoil_Full/VirginSoil_Full.ino
+++ b/examples/VirginSoil_Full/VirginSoil_Full.ino
@@ -29,6 +29,8 @@
 #define VERSION "V2.1.1"
 #define COMPDATE __DATE__ __TIME__
 #define MODEBUTTON 0
+//#define LOCAL_EEPROM_SIZE 2048	// optional definition parameter to allow for increased EEPROM size; up to 4096 for ESP8266
+//#define LOCAL_MAXNUMEXTRAFIELDS	// optional definition parameter to allow for increased firmware variables
 
 
 #include <IOTAppStory.h>

--- a/src/IOTAppStory.cpp
+++ b/src/IOTAppStory.cpp
@@ -32,7 +32,7 @@ IOTAppStory::IOTAppStory(const char *appName, const char *appVersion, const char
 	preSetConfig((String)appName, false);
 }
 
-void IOTAppStory::firstBoot(bool ea){
+void IOTAppStory::firstBoot(bool ea, bool ee){
 	DEBUG_PRINTF(" Running first boot sequence for %s\n", _firmware.c_str());
 
 	// THIS ONLY RUNS ON THE FIRST BOOT OF A JUST INSTALLED APP (OR AFTER RESET TO DEFAULT SETTINGS) <-----------------------------------------------------------------------------------------------------------------
@@ -51,9 +51,12 @@ void IOTAppStory::firstBoot(bool ea){
 		emty = "";
 		emty.toCharArray(config.ssid, STRUCT_CHAR_ARRAY_SIZE);
 		emty.toCharArray(config.password, STRUCT_CHAR_ARRAY_SIZE);
-	}else{
+	}else if(ee == true){
 		DEBUG_PRINTLN(" Erasing EEPROM but leaving config settings");
 		eraseFlash((sizeof(config)+2),EEPROM_SIZE);		// erase eeprom but leave the config settings
+	}else{
+		DEBUG_PRINTLN(" Leaving EEPROM and config settings");
+		// not erasing EEPROM or config settings
 	}
 	
 	// update first boot config flag (date)
@@ -104,7 +107,7 @@ void IOTAppStory::preSetConfig(String ssid, String password, String boardName, S
 	_setPreSet = true;
 }
 
-void IOTAppStory::begin(bool bootstats, bool ea){
+void IOTAppStory::begin(bool bootstats, bool ea, bool ee){
 	DEBUG_PRINTLN("\n");
 
 	if(_setPreSet == true){
@@ -138,7 +141,7 @@ void IOTAppStory::begin(bool bootstats, bool ea){
 
 	// on first boot of the app run the firstBoot() function
 	if(String(config.compDate) != String(_compDate)){
-		firstBoot(ea);
+		firstBoot(ea, ee);
 	}
 
 	// process added fields

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -133,7 +133,7 @@
             void preSetConfig(String ssid, String password, String boardName, String IOTappStory1, String IOTappStoryPHP1, bool automaticUpdate = false);
 
             void begin(bool bootstats=true, bool ea=false, bool ee=false); 			// ea = erase all eeprom, ee = erase EEPROM only
-            void firstBoot(bool ea=false, ee=false);
+            void firstBoot(bool ea=false, bool ee=false);
 
             bool readRTCmem();
             void writeRTCmem();

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -132,8 +132,8 @@
             void preSetConfig(String ssid, String password, String boardName, bool automaticUpdate = false);
             void preSetConfig(String ssid, String password, String boardName, String IOTappStory1, String IOTappStoryPHP1, bool automaticUpdate = false);
 
-            void begin(bool bootstats=true, bool ea=false); 			// ea = erase all eeprom
-            void firstBoot(bool ea=false);
+            void begin(bool bootstats=true, bool ea=false, bool ee=false); 			// ea = erase all eeprom, ee = erase EEPROM only
+            void firstBoot(bool ea=false, ee=false);
 
             bool readRTCmem();
             void writeRTCmem();

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -6,16 +6,16 @@
     /* ------ ------ ------ DEFINES for library ------ ------ ------ */
     #define MAGICBYTES "CFG"
     
-    // allow for local user definition of EEPROM_SIZE to accomidate additional size needs; ESP8266 allows up to 4096
-    #if defined LOCAL_EEPROM_SIZE
-        #define EEPROM_SIZE LOCAL_EEPROM_SIZE
+    // allow for larger firmware when using an ESP8266
+    #ifdef ESP8266
+        #define EEPROM_SIZE 4096
     #else
         #define EEPROM_SIZE 1024
     #endif
     
-    // allow for lcal user definition of MAXNUMEXTRAFIELDS to accomidate additional firmware variables
-    #if defined LOCAL_MAXNUMEXTRAFIELDS
-        #define MAXNUMEXTRAFIELDS LOCAL_MAXNUMEXTRAFIELDS
+    // allow for more firmware variables when using an ESP8266
+    #ifdef ESP8266
+        #define MAXNUMEXTRAFIELDS 24
     #else
         #define MAXNUMEXTRAFIELDS 12
     #endif

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -7,14 +7,14 @@
     #define MAGICBYTES "CFG"
     
     // allow for local user definition of EEPROM_SIZE to accomidate additional size needs; ESP8266 allows up to 4096
-    #ifdef LOCAL_EEPROM_SIZE
+    #if defined LOCAL_EEPROM_SIZE
         #define EEPROM_SIZE LOCAL_EEPROM_SIZE
     #else
         #define EEPROM_SIZE 1024
     #endif
     
     // allow for lcal user definition of MAXNUMEXTRAFIELDS to accomidate additional firmware variables
-    #ifdef LOCAL_MAXNUMEXTRAFIELDS
+    #if defined LOCAL_MAXNUMEXTRAFIELDS
         #define MAXNUMEXTRAFIELDS LOCAL_MAXNUMEXTRAFIELDS
     #else
         #define MAXNUMEXTRAFIELDS 12

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -8,7 +8,7 @@
     
     // allow for local user definition of EEPROM_SIZE to accomidate additional size needs; ESP8266 allows up to 4096
     #ifdef LOCAL_EEPROM_SIZE
-        #define EEPROM_SIZE LOCAL_EEPROM_SZIE
+        #define EEPROM_SIZE LOCAL_EEPROM_SIZE
     #else
         #define EEPROM_SIZE 1024
     #endif

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -5,8 +5,21 @@
 
     /* ------ ------ ------ DEFINES for library ------ ------ ------ */
     #define MAGICBYTES "CFG"
-    #define EEPROM_SIZE 1024
-    #define MAXNUMEXTRAFIELDS 12
+    
+    // allow for local user definition of EEPROM_SIZE to accomidate additional size needs; ESP8266 allows up to 4096
+    #ifdef LOCAL_EEPROM_SIZE
+        #define EEPROM_SIZE LOCAL_EEPROM_SZIE
+    #else
+        #define EEPROM_SIZE 1024
+    #endif
+    
+    // allow for lcal user definition of MAXNUMEXTRAFIELDS to accomidate additional firmware variables
+    #ifdef LOCAL_MAXNUMEXTRAFIELDS
+        #define MAXNUMEXTRAFIELDS LOCAL_MAXNUMEXTRAFIELDS
+    #else
+        #define MAXNUMEXTRAFIELDS 12
+    #endif
+
     #define MAGICEEP "%"
     #define UDP_PORT 514
     #define MAX_WIFI_RETRIES 15


### PR DESCRIPTION
1. Allow optional setting of EEPROM_SIZE and MAXNUMEXTRAFIELDS prior to compilation.
2. Add the option to specify if any of the EEPROM should be cleared on first boot in addition to the choice to clear the entire EEPROM.

_In addition updated README and Examples to incorporate the above additions._