### PR TITLE
Move call home functionality completely into library

### DIFF
--- a/examples/VirginSoil_Basic/VirginSoil_Basic.ino
+++ b/examples/VirginSoil_Basic/VirginSoil_Basic.ino
@@ -50,7 +50,7 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.buttonLoop();																   // this routine handles the reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
+  IAS.loop();																   // this routine handles the reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
 
   //-------- Your Sketch starts from here ---------------
 

--- a/examples/VirginSoil_Full/VirginSoil_Full.ino
+++ b/examples/VirginSoil_Full/VirginSoil_Full.ino
@@ -37,7 +37,7 @@ IOTAppStory IAS(APPNAME, VERSION, COMPDATE, MODEBUTTON);
 
 
 // ================================================ EXAMPLE VARS =========================================
-unsigned long printEntry;
+
 
 // We want to be able to edit these example variables from the wifi config manager
 // Currently only char arrays are supported.
@@ -75,8 +75,9 @@ void setup() {
   /* TIP! delete the lines above when not used */
 
 
-  IAS.begin(true);																										// 1st parameter: true or false to view BOOT STATISTICS | 2nd parameter: true or false to erase eeprom on first boot of the app
-
+  IAS.begin(true);													 // 1st parameter: true or false to view BOOT STATISTICS | 2nd parameter: true or false to erase eeprom on first boot of the app
+  IAS.setCallHome(true);											 // Set to true to enable calling home frequently (disabled by default)
+  IAS.setCallHomeInterval(60);										 // Call home interval in seconds, use 60s only for development. Please change it to at least 2 hours in production
 
   //-------- Your Setup starts from here ---------------
 
@@ -86,13 +87,7 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.buttonLoop();                                                 // this routine handles the reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
-
-  if (millis() - callHomeEntry > 60000) {                          // only for development. Please change it to at least 2 hours in production
-    IAS.callHome();
-    callHomeEntry = millis();
-  }
-
+  IAS.loop();                                                 // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
 
 
   //-------- Your Sketch starts from here ---------------

--- a/src/IOTAppStory.cpp
+++ b/src/IOTAppStory.cpp
@@ -722,11 +722,11 @@ bool IOTAppStory::readConfig() {
 	return ret;
 }
 
-void IOTAppStory::Loop() {
-   this.buttonLoop();
+void IOTAppStory::loop() {
+   this->buttonLoop();
 
    if (_callHome && millis() - _lastCallHomeTime > _callHomeInterval) {
-      this.callHome();
+      this->callHome();
       _lastCallHomeTime = millis();
    }
 }
@@ -797,5 +797,5 @@ void IOTAppStory::setCallHome(bool callHome) {
 }
 
 void IOTAppStory::setCallHomeInterval(unsigned long interval) {
-   _callHomeInterval = interval * 1000 //Convert to millis so users can pass seconds to this function
+   _callHomeInterval = interval * 1000; //Convert to millis so users can pass seconds to this function
 }

--- a/src/IOTAppStory.cpp
+++ b/src/IOTAppStory.cpp
@@ -722,6 +722,14 @@ bool IOTAppStory::readConfig() {
 	return ret;
 }
 
+void IOTAppStory::Loop() {
+   this.buttonLoop();
+
+   if (_callHome && millis() - _lastCallHomeTime > _callHomeInterval) {
+      this.callHome();
+      _lastCallHomeTime = millis();
+   }
+}
 
 void IOTAppStory::buttonLoop() {
   unsigned long _buttonTime = -1;
@@ -783,3 +791,11 @@ void IOTAppStory::sendDebugMessage() {
 	//sendSysLogMessage(6, 1, config.boardName, FIRMWARE, 10, counter++, sysMessage);
 }
 */
+
+void IOTAppStory::setCallHome(bool callHome) {
+   _callHome = callHome;
+}
+
+void IOTAppStory::setCallHomeInterval(unsigned long interval) {
+   _callHomeInterval = interval * 1000 //Convert to millis so users can pass seconds to this function
+}

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -146,10 +146,14 @@
 
             void writeConfig(bool wifiSave=false);
             bool readConfig();
+            void loop();
             void buttonLoop();
             void JSONerror(String err);
             void saveConfigCallback();
             void sendDebugMessage();
+            
+            void setCallHome(bool callHome);
+            void setCallHomeInterval(unsigned long interval);
 
         private:
             //String  _appName;				// may not be necessary
@@ -160,6 +164,9 @@
             int     _nrXF = 0;				// nr of extra fields required in the config manager
             bool    _serialDebug;
             bool    _setPreSet = false;		// ;)
+            bool    _callHome = false;
+            unsigned long _lastCallHomeTime; //Time when we last called home
+            unsigned long _callHomeInterval = 7200000  //Interval we want to call home at in milliseconds, default start at 2hrs
     };
 
 #endif

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -166,7 +166,7 @@
             bool    _setPreSet = false;		// ;)
             bool    _callHome = false;
             unsigned long _lastCallHomeTime; //Time when we last called home
-            unsigned long _callHomeInterval = 7200000  //Interval we want to call home at in milliseconds, default start at 2hrs
+            unsigned long _callHomeInterval = 7200000;  //Interval we want to call home at in milliseconds, default start at 2hrs
     };
 
 #endif


### PR DESCRIPTION
I've modified the library so that the call home functionality is simply configurable using 2 new public functions:
- `void IOTAppStory::setCallHome(bool callHome = false)` allows to completely enable/disable calling home, defaults to `false`
- `void IOTAppStory::setCallHomeInterval(unsigned long interval = 7200)` allows to define in seconds the interval at which we should check for updates, defaults to 2 hours (7200s)

I've created a general `IOTAppStory::loop()` function for the library which will do 2 things:
- call `buttonLoop()` function every time (so this is not necessary in the main sketch anymore)
- perform call home functionality if it is enabled, and at the correct interval that was configured.

The `IOTAppStory::loop()` function should be called in the main sketch's `loop()`.

I've also modified the virgin soil examples to represent these changes.