### PR TITLE
Move call home functionality completely into library (Followup of #26)

### DIFF
--- a/examples/VirginSoil_Basic/VirginSoil_Basic.ino
+++ b/examples/VirginSoil_Basic/VirginSoil_Basic.ino
@@ -54,7 +54,7 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.buttonLoop();																   // this routine handles the reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
+  IAS.loop();																   // this routine handles the reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
 
   //-------- Your Sketch starts from here ---------------
 

--- a/examples/VirginSoil_Basic/VirginSoil_Basic.ino
+++ b/examples/VirginSoil_Basic/VirginSoil_Basic.ino
@@ -54,7 +54,7 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.loop();																   // this routine handles the reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
+  IAS.buttonLoop();																   // this routine handles the reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
 
   //-------- Your Sketch starts from here ---------------
 

--- a/examples/VirginSoil_Full/VirginSoil_Full.ino
+++ b/examples/VirginSoil_Full/VirginSoil_Full.ino
@@ -37,7 +37,7 @@ IOTAppStory IAS(APPNAME, VERSION, COMPDATE, MODEBUTTON);
 
 
 // ================================================ EXAMPLE VARS =========================================
-unsigned long printEntry;
+
 
 // We want to be able to edit these example variables from the wifi config manager
 // Currently only char arrays are supported.
@@ -80,6 +80,8 @@ void setup() {
   IAS.begin(true,'P');
 	//IAS.begin();
 	//IAS.begin(true);
+  IAS.setCallHome(true);											 // Set to true to enable calling home frequently (disabled by default)
+  IAS.setCallHomeInterval(60);										 // Call home interval in seconds, use 60s only for development. Please change it to at least 2 hours in production
 
 
   // You can configure callback functions that can give feedback to the app user about the current state of the application.
@@ -127,13 +129,7 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.buttonLoop();                                                 // this routine handles the reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
-
-  if (millis() - callHomeEntry > 60000) {                           // only for development. Please change it to at least 2 hours in production
-    IAS.callHome();
-    callHomeEntry = millis();
-  }
-
+  IAS.loop();                                                 // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
 
 
   //-------- Your Sketch starts from here ---------------

--- a/examples/VirginSoil_Full/VirginSoil_Full.ino
+++ b/examples/VirginSoil_Full/VirginSoil_Full.ino
@@ -129,7 +129,7 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.loop();                                                 // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
+  IAS.buttonLoop();                                                 // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
 
 
   //-------- Your Sketch starts from here ---------------

--- a/src/IOTAppStory.cpp
+++ b/src/IOTAppStory.cpp
@@ -892,16 +892,20 @@ void IOTAppStory::onModeButtonNoPress(THandlerFunction value) {
 	_noPressCallback = value;
 }
 
+void IOTAppStory::setCallHome(bool callHome) {
+   _callHome = callHome;
+}
+
+void IOTAppStory::setCallHomeInterval(unsigned long interval) {
+   _callHomeInterval = interval * 1000; //Convert to millis so users can pass seconds to this function
+}
+
 void IOTAppStory::onModeButtonShortPress(THandlerFunction value) {
 	_shortPressCallback = value;
 }
 
 void IOTAppStory::onModeButtonLongPress(THandlerFunction value) {
 	_longPressCallback = value;
-}
-
-void IOTAppStory::setCallHomeInterval(unsigned long interval) {
-   _callHomeInterval = interval * 1000; //Convert to millis so users can pass seconds to this function
 }
 
 void IOTAppStory::onModeButtonVeryLongPress(THandlerFunction value) {

--- a/src/IOTAppStory.cpp
+++ b/src/IOTAppStory.cpp
@@ -789,9 +789,17 @@ bool IOTAppStory::readConfig() {
 	return ret;
 }
 
+void IOTAppStory::loop() {
+   this->buttonLoop();
+
+   if (_callHome && millis() - _lastCallHomeTime > _callHomeInterval) {
+      this->callHome();
+      _lastCallHomeTime = millis();
+   }
+}
 
 ModeButtonState IOTAppStory::buttonLoop() {
-	return getModeButtonState();
+   return getModeButtonState();
 }
 
 void IOTAppStory::saveConfigCallback () {        								// <<-- could be deleted ?
@@ -890,6 +898,10 @@ void IOTAppStory::onModeButtonShortPress(THandlerFunction value) {
 
 void IOTAppStory::onModeButtonLongPress(THandlerFunction value) {
 	_longPressCallback = value;
+}
+
+void IOTAppStory::setCallHomeInterval(unsigned long interval) {
+   _callHomeInterval = interval * 1000; //Convert to millis so users can pass seconds to this function
 }
 
 void IOTAppStory::onModeButtonVeryLongPress(THandlerFunction value) {

--- a/src/IOTAppStory.cpp
+++ b/src/IOTAppStory.cpp
@@ -789,9 +789,7 @@ bool IOTAppStory::readConfig() {
 	return ret;
 }
 
-void IOTAppStory::loop() {
-   this->buttonLoop();
-
+void IOTAppStory::updateLoop() {
    if (_callHome && millis() - _lastCallHomeTime > _callHomeInterval) {
       this->callHome();
       _lastCallHomeTime = millis();
@@ -799,6 +797,7 @@ void IOTAppStory::loop() {
 }
 
 ModeButtonState IOTAppStory::buttonLoop() {
+   this->updateLoop();
    return getModeButtonState();
 }
 

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -203,6 +203,7 @@
 
             void writeConfig(bool wifiSave=false);
             bool readConfig();
+            void loop();
             ModeButtonState buttonLoop();
             void JSONerror(String err);
             void saveConfigCallback();
@@ -228,6 +229,9 @@
             // called when the app is about to enter in configuration mode
             void onModeButtonConfigMode(THandlerFunction fn);
     
+            
+            void setCallHome(bool callHome);
+            void setCallHomeInterval(unsigned long interval);
 
         private:
             //const char *_appName;

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -175,7 +175,7 @@
 
             void begin(bool bootstats=true);
             void begin(bool bootstats, bool ea); 			// for backwards comp | depreciated use begin(bool bootstats, char) instead
-						void begin(bool bootstats, char ea='P'); 
+				void begin(bool bootstats, char ea='P'); 
             void firstBoot(char ea);
 
 
@@ -203,7 +203,7 @@
 
             void writeConfig(bool wifiSave=false);
             bool readConfig();
-            void loop();
+            void updateLoop();
             ModeButtonState buttonLoop();
             void JSONerror(String err);
             void saveConfigCallback();

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -286,6 +286,9 @@
                 return String("[" + String(value, DEC) + "]");
               } 
             }
+            bool    _callHome = false;
+            unsigned long _lastCallHomeTime; //Time when we last called home
+            unsigned long _callHomeInterval = 7200000;  //Interval we want to call home at in milliseconds, default start at 2hrs
     };
 
 #endif


### PR DESCRIPTION
I had to create a new PR since I was asked to make a PR to develop instead of master.
See #26 for historic details.

I've modified the library so that the call home functionality is simply configurable using 2 new public functions:
- `void IOTAppStory::setCallHome(bool callHome = false)` allows to completely enable/disable calling home, defaults to `false`
- `void IOTAppStory::setCallHomeInterval(unsigned long interval = 7200)` allows to define in seconds the interval at which we should check for updates, defaults to 2 hours (7200s)

I've created a `IOTAppStory::updateLoop()` function for the library which will perform call home functionality if it is enabled, and at the correct interval that was configured.

The `IOTAppStory::updateLoop()` function is called from the `IOTAppStory::buttonLoop()` function so calling `buttonLoop()` from the main sketch's loop will ensure calling home happens as it is configured.

I've also modified the virgin soil examples to represent these changes.